### PR TITLE
MPTCP: implementation of mptcp

### DIFF
--- a/auto/unix
+++ b/auto/unix
@@ -533,6 +533,15 @@ ngx_feature_libs=
 ngx_feature_test="setsockopt(0, IPPROTO_TCP, TCP_FASTOPEN, NULL, 0)"
 . auto/feature
 
+ngx_feature="MPTCP"
+ngx_feature_name="NGX_HAVE_MPTCP"
+ngx_feature_run=no
+ngx_feature_incs="#include <sys/socket.h>
+                  #include <netinet/in.h>"
+ngx_feature_path=
+ngx_feature_libs=
+ngx_feature_test="socket(AF_INET, SOCK_STREAM, IPPROTO_MPTCP)"
+. auto/feature
 
 ngx_feature="TCP_INFO"
 ngx_feature_name="NGX_HAVE_TCP_INFO"

--- a/auto/unix
+++ b/auto/unix
@@ -533,6 +533,7 @@ ngx_feature_libs=
 ngx_feature_test="setsockopt(0, IPPROTO_TCP, TCP_FASTOPEN, NULL, 0)"
 . auto/feature
 
+
 ngx_feature="TCP_INFO"
 ngx_feature_name="NGX_HAVE_TCP_INFO"
 ngx_feature_run=no

--- a/auto/unix
+++ b/auto/unix
@@ -533,16 +533,6 @@ ngx_feature_libs=
 ngx_feature_test="setsockopt(0, IPPROTO_TCP, TCP_FASTOPEN, NULL, 0)"
 . auto/feature
 
-ngx_feature="MPTCP"
-ngx_feature_name="NGX_HAVE_MPTCP"
-ngx_feature_run=no
-ngx_feature_incs="#include <sys/socket.h>
-                  #include <netinet/in.h>"
-ngx_feature_path=
-ngx_feature_libs=
-ngx_feature_test="socket(AF_INET, SOCK_STREAM, IPPROTO_MPTCP)"
-. auto/feature
-
 ngx_feature="TCP_INFO"
 ngx_feature_name="NGX_HAVE_TCP_INFO"
 ngx_feature_run=no

--- a/src/core/ngx_connection.c
+++ b/src/core/ngx_connection.c
@@ -78,6 +78,7 @@ ngx_create_listening(ngx_conf_t *cf, struct sockaddr *sockaddr,
 
     ls->fd = (ngx_socket_t) -1;
     ls->type = SOCK_STREAM;
+    ls->protocol = 0;
 
     ls->backlog = NGX_LISTEN_BACKLOG;
     ls->rcvbuf = -1;
@@ -487,8 +488,12 @@ ngx_open_listening_sockets(ngx_cycle_t *cycle)
                 continue;
             }
 
+#if (NGX_HAVE_MPTCP)
+            s = ngx_socket(ls[i].sockaddr->sa_family, ls[i].type,
+                            ls[i].protocol);
+#else
             s = ngx_socket(ls[i].sockaddr->sa_family, ls[i].type, 0);
-
+#endif
             if (s == (ngx_socket_t) -1) {
                 ngx_log_error(NGX_LOG_EMERG, log, ngx_socket_errno,
                               ngx_socket_n " %V failed", &ls[i].addr_text);

--- a/src/core/ngx_connection.c
+++ b/src/core/ngx_connection.c
@@ -488,15 +488,14 @@ ngx_open_listening_sockets(ngx_cycle_t *cycle)
                 continue;
             }
 
-#if (NGX_LINUX)
             s = (ngx_socket_t) -1;
-            if (ls[i].protocol > 0)
+            if (ls[i].protocol > 0) {
                 s = ngx_socket(ls[i].sockaddr->sa_family, ls[i].type,
                                ls[i].protocol);
-            if (s == (ngx_socket_t) -1)
-#endif
-            s = ngx_socket(ls[i].sockaddr->sa_family, ls[i].type, 0);
-
+            }
+            if (s == (ngx_socket_t) -1) {
+                s = ngx_socket(ls[i].sockaddr->sa_family, ls[i].type, 0);
+            }
             if (s == (ngx_socket_t) -1) {
                 ngx_log_error(NGX_LOG_EMERG, log, ngx_socket_errno,
                               ngx_socket_n " %V failed", &ls[i].addr_text);

--- a/src/core/ngx_connection.c
+++ b/src/core/ngx_connection.c
@@ -78,7 +78,6 @@ ngx_create_listening(ngx_conf_t *cf, struct sockaddr *sockaddr,
 
     ls->fd = (ngx_socket_t) -1;
     ls->type = SOCK_STREAM;
-    ls->protocol = 0;
 
     ls->backlog = NGX_LISTEN_BACKLOG;
     ls->rcvbuf = -1;

--- a/src/core/ngx_connection.c
+++ b/src/core/ngx_connection.c
@@ -488,7 +488,7 @@ ngx_open_listening_sockets(ngx_cycle_t *cycle)
                 continue;
             }
 
-#if (NGX_HAVE_MPTCP)
+#if (NGX_LINUX)
             s = (ngx_socket_t) -1;
             if (ls[i].protocol > 0)
                 s = ngx_socket(ls[i].sockaddr->sa_family, ls[i].type,

--- a/src/core/ngx_connection.c
+++ b/src/core/ngx_connection.c
@@ -492,11 +492,11 @@ ngx_open_listening_sockets(ngx_cycle_t *cycle)
             s = (ngx_socket_t) -1;
             if (ls[i].protocol > 0)
                 s = ngx_socket(ls[i].sockaddr->sa_family, ls[i].type,
-                            ls[i].protocol);
+                               ls[i].protocol);
             if (s == (ngx_socket_t) -1)
 #endif
             s = ngx_socket(ls[i].sockaddr->sa_family, ls[i].type, 0);
-            
+
             if (s == (ngx_socket_t) -1) {
                 ngx_log_error(NGX_LOG_EMERG, log, ngx_socket_errno,
                               ngx_socket_n " %V failed", &ls[i].addr_text);

--- a/src/core/ngx_connection.c
+++ b/src/core/ngx_connection.c
@@ -489,11 +489,14 @@ ngx_open_listening_sockets(ngx_cycle_t *cycle)
             }
 
 #if (NGX_HAVE_MPTCP)
-            s = ngx_socket(ls[i].sockaddr->sa_family, ls[i].type,
+            s = (ngx_socket_t) -1;
+            if (ls[i].protocol > 0)
+                s = ngx_socket(ls[i].sockaddr->sa_family, ls[i].type,
                             ls[i].protocol);
-#else
-            s = ngx_socket(ls[i].sockaddr->sa_family, ls[i].type, 0);
+            if (s == (ngx_socket_t) -1)
 #endif
+            s = ngx_socket(ls[i].sockaddr->sa_family, ls[i].type, 0);
+            
             if (s == (ngx_socket_t) -1) {
                 ngx_log_error(NGX_LOG_EMERG, log, ngx_socket_errno,
                               ngx_socket_n " %V failed", &ls[i].addr_text);

--- a/src/core/ngx_connection.c
+++ b/src/core/ngx_connection.c
@@ -487,8 +487,14 @@ ngx_open_listening_sockets(ngx_cycle_t *cycle)
                 continue;
             }
 
-            s = ngx_socket(ls[i].sockaddr->sa_family, ls[i].type, 0);
-
+            s = (ngx_socket_t) -1;
+            if (ls[i].protocol > 0) {
+                s = ngx_socket(ls[i].sockaddr->sa_family, ls[i].type,
+                               ls[i].protocol);
+            }
+            if (s == (ngx_socket_t) -1) {
+                s = ngx_socket(ls[i].sockaddr->sa_family, ls[i].type, 0);
+            }
             if (s == (ngx_socket_t) -1) {
                 ngx_log_error(NGX_LOG_EMERG, log, ngx_socket_errno,
                               ngx_socket_n " %V failed", &ls[i].addr_text);

--- a/src/core/ngx_connection.h
+++ b/src/core/ngx_connection.h
@@ -24,6 +24,7 @@ struct ngx_listening_s {
     ngx_str_t           addr_text;
 
     int                 type;
+    int                 protocol;
 
     int                 backlog;
     int                 rcvbuf;

--- a/src/http/ngx_http.c
+++ b/src/http/ngx_http.c
@@ -1845,6 +1845,7 @@ ngx_http_add_listening(ngx_conf_t *cf, ngx_http_conf_addr_t *addr)
 #endif
 
     ls->type = addr->opt.type;
+    ls->protocol = addr->opt.protocol;
     ls->backlog = addr->opt.backlog;
     ls->rcvbuf = addr->opt.rcvbuf;
     ls->sndbuf = addr->opt.sndbuf;

--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -4049,6 +4049,13 @@ ngx_http_core_listen(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         }
 #endif
 
+#if (NGX_LINUX)
+        if (ngx_strcmp(value[n].data, "mptcp") == 0) {
+            lsopt.protocol = IPPROTO_MPTCP;
+            continue;
+        }
+#endif
+
         if (ngx_strncmp(value[n].data, "backlog=", 8) == 0) {
             lsopt.backlog = ngx_atoi(value[n].data + 8, value[n].len - 8);
             lsopt.set = 1;

--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -4049,7 +4049,7 @@ ngx_http_core_listen(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         }
 #endif
 
-#if (NGX_HAVE_MPTCP)
+#if (NGX_LINUX)
         if (ngx_strcmp(value[n].data, "mptcp") == 0) {
             lsopt.protocol = IPPROTO_MPTCP;
             continue;

--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -4049,6 +4049,13 @@ ngx_http_core_listen(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         }
 #endif
 
+#if (NGX_HAVE_MPTCP)
+        if (ngx_strcmp(value[n].data, "mptcp") == 0) {
+            lsopt.protocol = IPPROTO_MPTCP;
+            continue;
+        }
+#endif
+
         if (ngx_strncmp(value[n].data, "backlog=", 8) == 0) {
             lsopt.backlog = ngx_atoi(value[n].data + 8, value[n].len - 8);
             lsopt.set = 1;

--- a/src/http/ngx_http_core_module.h
+++ b/src/http/ngx_http_core_module.h
@@ -88,6 +88,7 @@ typedef struct {
     int                        rcvbuf;
     int                        sndbuf;
     int                        type;
+    int                        protocol;
 #if (NGX_HAVE_SETFIB)
     int                        setfib;
 #endif

--- a/src/stream/ngx_stream_core_module.c
+++ b/src/stream/ngx_stream_core_module.c
@@ -654,6 +654,13 @@ ngx_stream_core_listen(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         }
 #endif
 
+#if (NGX_LINUX)
+        if (ngx_strcmp(value[n].data, "mptcp") == 0) {
+            lsopt.protocol = IPPROTO_MPTCP;
+            continue;
+        }
+#endif
+
         if (ngx_strncmp(value[i].data, "backlog=", 8) == 0) {
             ls->backlog = ngx_atoi(value[i].data + 8, value[i].len - 8);
             ls->bind = 1;


### PR DESCRIPTION
This PR is internal, and aims to implement MPTCP (defined in RFC8684) into the nginx socket creation process.
The current approach is to add an option to the `listen` directive (namely `mptcp`) to enable and disable the protocol.

It would be interesting to have it set by the `http`or `server` blocks but I don't currently see a good way of doing so. 

In this initial commit MPTCP is disabled by default simply because it is easy to implement, but it is preferable to have is on by default and give the option to user to explicitly disable it.  