### PR TITLE
MPTCP: add support and listen option

### DIFF
--- a/contrib/vim/syntax/nginx.vim
+++ b/contrib/vim/syntax/nginx.vim
@@ -65,7 +65,7 @@ syn match ngxListenComment '#.*$'
     \ contained
     \ nextgroup=@ngxListenParams skipwhite skipempty
 syn keyword ngxListenOptions contained
-    \ default_server ssl quic proxy_protocol
+    \ default_server ssl quic proxy_protocol mptcp
     \ setfib fastopen backlog rcvbuf sndbuf accept_filter deferred bind
     \ ipv6only reuseport so_keepalive
     \ nextgroup=@ngxListenParams skipwhite skipempty

--- a/src/core/ngx_connection.h
+++ b/src/core/ngx_connection.h
@@ -24,6 +24,7 @@ struct ngx_listening_s {
     ngx_str_t           addr_text;
 
     int                 type;
+    int                 protocol;
 
     int                 backlog;
     int                 rcvbuf;

--- a/src/http/ngx_http.c
+++ b/src/http/ngx_http.c
@@ -1845,6 +1845,7 @@ ngx_http_add_listening(ngx_conf_t *cf, ngx_http_conf_addr_t *addr)
 #endif
 
     ls->type = addr->opt.type;
+    ls->protocol = addr->opt.protocol;
     ls->backlog = addr->opt.backlog;
     ls->rcvbuf = addr->opt.rcvbuf;
     ls->sndbuf = addr->opt.sndbuf;

--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -20,6 +20,10 @@ typedef struct {
 #define NGX_HTTP_REQUEST_BODY_FILE_ON     1
 #define NGX_HTTP_REQUEST_BODY_FILE_CLEAN  2
 
+#ifndef IPPROTO_MPTCP
+#define IPPROTO_MPTCP 262
+#endif
+
 
 static ngx_int_t ngx_http_core_auth_delay(ngx_http_request_t *r);
 static void ngx_http_core_auth_delay_handler(ngx_http_request_t *r);
@@ -4049,6 +4053,13 @@ ngx_http_core_listen(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         }
 #endif
 
+#if (NGX_LINUX)
+        if (ngx_strcmp(value[n].data, "mptcp") == 0) {
+            lsopt.protocol = IPPROTO_MPTCP;
+            continue;
+        }
+#endif
+
         if (ngx_strncmp(value[n].data, "backlog=", 8) == 0) {
             lsopt.backlog = ngx_atoi(value[n].data + 8, value[n].len - 8);
             lsopt.set = 1;
@@ -4351,6 +4362,11 @@ ngx_http_core_listen(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         if (lsopt.proxy_protocol) {
             return "\"proxy_protocol\" parameter is incompatible with \"quic\"";
         }
+#if (NGX_LINUX)
+        if (lsopt.protocol == IPPROTO_MPTCP) {
+             return "\"mptcp\" parameter is incompatible with \"quic\"";
+        }
+#endif
     }
 
     for (n = 0; n < u.naddrs; n++) {

--- a/src/http/ngx_http_core_module.h
+++ b/src/http/ngx_http_core_module.h
@@ -88,6 +88,7 @@ typedef struct {
     int                        rcvbuf;
     int                        sndbuf;
     int                        type;
+    int                        protocol;
 #if (NGX_HAVE_SETFIB)
     int                        setfib;
 #endif

--- a/src/mail/ngx_mail.c
+++ b/src/mail/ngx_mail.c
@@ -332,6 +332,7 @@ ngx_mail_optimize_servers(ngx_conf_t *cf, ngx_array_t *ports)
             ls->log.data = &ls->addr_text;
             ls->log.handler = ngx_accept_log_error;
 
+            ls->protocol = addr[i].opt.protocol;
             ls->backlog = addr[i].opt.backlog;
             ls->rcvbuf = addr[i].opt.rcvbuf;
             ls->sndbuf = addr[i].opt.sndbuf;

--- a/src/mail/ngx_mail.h
+++ b/src/mail/ngx_mail.h
@@ -47,6 +47,7 @@ typedef struct {
     int                     tcp_keepintvl;
     int                     tcp_keepcnt;
 #endif
+    int                     protocol;
     int                     backlog;
     int                     rcvbuf;
     int                     sndbuf;

--- a/src/mail/ngx_mail_core_module.c
+++ b/src/mail/ngx_mail_core_module.c
@@ -10,6 +10,10 @@
 #include <ngx_event.h>
 #include <ngx_mail.h>
 
+#ifndef IPPROTO_MPTCP
+#define IPPROTO_MPTCP 262
+#endif
+
 
 static void *ngx_mail_core_create_main_conf(ngx_conf_t *cf);
 static void *ngx_mail_core_create_srv_conf(ngx_conf_t *cf);
@@ -466,6 +470,11 @@ ngx_mail_core_listen(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
                                "ngx_mail_ssl_module");
             return NGX_CONF_ERROR;
 #endif
+        }
+
+        if (ngx_strcmp(value[i].data, "mptcp") == 0) {
+            ls->protocol = IPPROTO_MPTCP;
+            continue;
         }
 
         if (ngx_strncmp(value[i].data, "so_keepalive=", 13) == 0) {

--- a/src/stream/ngx_stream.c
+++ b/src/stream/ngx_stream.c
@@ -1010,6 +1010,7 @@ ngx_stream_add_listening(ngx_conf_t *cf, ngx_stream_conf_addr_t *addr)
     ls->log.handler = ngx_accept_log_error;
 
     ls->type = addr->opt.type;
+    ls->protocol = addr->opt.protocol;
     ls->backlog = addr->opt.backlog;
     ls->rcvbuf = addr->opt.rcvbuf;
     ls->sndbuf = addr->opt.sndbuf;

--- a/src/stream/ngx_stream.h
+++ b/src/stream/ngx_stream.h
@@ -62,6 +62,7 @@ typedef struct {
     int                            rcvbuf;
     int                            sndbuf;
     int                            type;
+    int                            protocol;
 #if (NGX_HAVE_SETFIB)
     int                            setfib;
 #endif


### PR DESCRIPTION
This PR is internal, and aims to implement MPTCP (defined in RFC8684) into the nginx socket creation process.
The current approach is to add an option to the listen directive (namely mptcp) to enable and disable the protocol.

It would be interesting to have it set by the httpor server blocks but I don't currently see a good way of doing so.

In this initial commit MPTCP is disabled by default simply because it is easy to implement, but it is preferable to have is on by default and give the option to user to explicitly disable it.
